### PR TITLE
image 경로 설정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,7 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: |
-            ${{ env.REGISTRY }}
+            ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.REGISTRY }}
           tags: |
             ${{ github.sha }}
             latest


### PR DESCRIPTION
https://github.com/TimeTREE98/code-share-be/pull/3 이 PR 에서 작성한 deploy.yml 에서 image 경로가 잘못되어 [push fail](https://github.com/TimeTREE98/code-share-be/actions/runs/8517979490) 하는 문제를 고칩니다.