### PR TITLE
docker private hub 에 push 되게 변경

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,7 @@ on:
       - '**'
 
 env:
-  REGISTRY: code-share-be
+  REGISTRY: ${{ secrets.REGISTRY }}
 
 jobs:
   build-and-deploy:
@@ -23,7 +23,7 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: |
-            ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.REGISTRY }}
+            ${{ env.REGISTRY }}/code-share-be
           tags: |
             ${{ github.sha }}
             latest
@@ -31,8 +31,9 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build and Push
         uses: docker/build-push-action@v5


### PR DESCRIPTION
해당 서비스를 클라우드에서 돌리는 것이 아닌 개인 NAS 에 돌릴 예정이여서, NAS 에 세팅된 docker private hub 로 push 되게 변경합니다.